### PR TITLE
minor icon changes, added micorphone dispose functionality

### DIFF
--- a/app/src/main/java/pl/maciejwojs/ar00k/bestnotepadevercreaated/pages/CreateNotePage.kt
+++ b/app/src/main/java/pl/maciejwojs/ar00k/bestnotepadevercreaated/pages/CreateNotePage.kt
@@ -36,6 +36,7 @@ import androidx.compose.material.icons.filled.Bookmarks
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.LockOpen
 import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material.icons.filled.MicOff
 import androidx.compose.material.icons.filled.PhotoCamera
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -77,6 +78,7 @@ import pl.maciejwojs.ar00k.bestnotepadevercreaated.db.Tag
 import pl.maciejwojs.ar00k.bestnotepadevercreaated.playback.AndroidAudioPlayer
 import pl.maciejwojs.ar00k.bestnotepadevercreaated.record.AndroidAudioRecorder
 import pl.maciejwojs.ar00k.bestnotepadevercreaated.settings.iconModifier
+import pl.maciejwojs.ar00k.bestnotepadevercreaated.settings.iconWeightRatio
 import pl.maciejwojs.ar00k.bestnotepadevercreaated.ui.theme.BestNotepadEverCreatedTheme
 import java.io.File
 import java.net.URI
@@ -149,14 +151,28 @@ fun CreateNotePage(
 
     DisposableEffect(Unit) {
         onDispose {
+            showMicrophoneRecordComposable = false
+            Log.d("CreateNotePage", "Disposing( UNIT ) $showMicrophoneRecordComposable")
             saveNote()
+        }
+    }
+    DisposableEffect(showMicrophoneRecordComposable) {
+        onDispose {
+            Log.d("CreateNotePage", "Disposing( Record ) $showMicrophoneRecordComposable")
+            audioPlayer.stop()
+            audioRecorder.stop()
         }
     }
 
     if (showMicrophoneRecordComposable) {
         BestNotepadEverCreatedTheme {
             Scaffold { innerPadding ->
-                Column(modifier = Modifier.padding(innerPadding)) {
+                Row(
+                    modifier =
+                        Modifier
+                            .padding(innerPadding),
+                ) {
+                    var isBeingRecorded by remember { mutableStateOf(false) }
                     currentAudioFile.value = LocalDateTime.now()
                         .format(DateTimeFormatter.ofPattern("HH_mm_ss-dd_MM_yyyy")) + ".mp3"
                     val file =
@@ -165,16 +181,28 @@ fun CreateNotePage(
                             currentAudioFile.value!!,
                         )
                     file.parentFile?.mkdirs()
-                    Button(onClick = { audioRecorder.start(file) }) {
-                        Text("Start recording")
+                    IconButton(onClick = {
+                        if (!isBeingRecorded) {
+                            audioRecorder.start(file)
+                            isBeingRecorded = true
+                        } else {
+                            audioRecorder.stop()
+                            isBeingRecorded = false
+                            showMicrophoneRecordComposable = false
+                        }
+                    }) {
+                        Icon(
+                            imageVector = if (isBeingRecorded) Icons.Default.MicOff else Icons.Default.Mic,
+                            contentDescription = if (isBeingRecorded) "Stop recording" else "Start recording",
+                        )
                     }
 
-                    Button(onClick = {
-                        audioRecorder.stop()
-                        showMicrophoneRecordComposable = false
-                    }) {
-                        Text("Start recording")
-                    }
+//                    Button(onClick = {
+//                        audioRecorder.stop()
+//                        showMicrophoneRecordComposable = false
+//                    }) {
+//                        Text("Stop recording")
+//                    }
 //                    val audioFileDeferred = CompletableDeferred<File>()
 //                    audioRecorder(
 //                        { file ->
@@ -236,7 +264,10 @@ fun CreateNotePage(
                             ),
                 ) {
                     IconButton(
-                        modifier = Modifier.weight(1f).then(iconModifier),
+                        modifier =
+                            Modifier
+                                .weight(iconWeightRatio)
+                                .then(iconModifier),
                         onClick = { showBottomSheet = true },
                     ) {
                         Icon(imageVector = Icons.Default.Bookmarks, contentDescription = "Add tag")
@@ -244,7 +275,10 @@ fun CreateNotePage(
                     }
 
                     IconButton(
-                        modifier = Modifier.weight(1f).then(iconModifier),
+                        modifier =
+                            Modifier
+                                .weight(iconWeightRatio)
+                                .then(iconModifier),
                         onClick = {
                             requestCameraPermission()
                             showCameraPreview = true
@@ -257,7 +291,10 @@ fun CreateNotePage(
 //                        Text(text = "Take photo")
                     }
                     IconButton(
-                        modifier = Modifier.weight(1f).then(iconModifier),
+                        modifier =
+                            Modifier
+                                .weight(iconWeightRatio)
+                                .then(iconModifier),
                         onClick = {
                             requestMicrophonePermission()
                             showMicrophoneRecordComposable = true
@@ -271,7 +308,10 @@ fun CreateNotePage(
                     }
 
                     IconButton(
-                        modifier = Modifier.weight(1f).then(iconModifier),
+                        modifier =
+                            Modifier
+                                .weight(iconWeightRatio)
+                                .then(iconModifier),
                         onClick = {
                             isPrivate.value = !isPrivate.value
                             Toast.makeText(

--- a/app/src/main/java/pl/maciejwojs/ar00k/bestnotepadevercreaated/pages/EditNotePage.kt
+++ b/app/src/main/java/pl/maciejwojs/ar00k/bestnotepadevercreaated/pages/EditNotePage.kt
@@ -71,6 +71,7 @@ import pl.maciejwojs.ar00k.bestnotepadevercreaated.content.GenerateIconButton
 import pl.maciejwojs.ar00k.bestnotepadevercreaated.db.Note
 import pl.maciejwojs.ar00k.bestnotepadevercreaated.db.Tag
 import pl.maciejwojs.ar00k.bestnotepadevercreaated.settings.iconModifier
+import pl.maciejwojs.ar00k.bestnotepadevercreaated.settings.iconWeightRatio
 import pl.maciejwojs.ar00k.bestnotepadevercreaated.ui.theme.BestNotepadEverCreatedTheme
 import java.io.File
 import java.net.URI
@@ -216,7 +217,7 @@ fun EditNotePage(
                             ),
                 ) {
                     IconButton(
-                        modifier = Modifier.weight(1f).then(iconModifier),
+                        modifier = Modifier.weight(iconWeightRatio).then(iconModifier),
                         onClick = { showBottomSheet = true },
                     ) {
                         Icon(imageVector = Icons.Default.Bookmarks, contentDescription = "Add tag")
@@ -224,7 +225,7 @@ fun EditNotePage(
                     }
 
                     IconButton(
-                        modifier = Modifier.weight(1f).then(iconModifier),
+                        modifier = Modifier.weight(iconWeightRatio).then(iconModifier),
                         onClick = {
                             requestCameraPermission()
                             showCameraPreview = true
@@ -238,7 +239,7 @@ fun EditNotePage(
                     }
 
                     IconButton(
-                        modifier = Modifier.weight(1f).then(iconModifier),
+                        modifier = Modifier.weight(iconWeightRatio).then(iconModifier),
                         onClick = {
                             isPrivate.value = !isPrivate.value
                             Toast.makeText(

--- a/app/src/main/java/pl/maciejwojs/ar00k/bestnotepadevercreaated/settings/globalValues.kt
+++ b/app/src/main/java/pl/maciejwojs/ar00k/bestnotepadevercreaated/settings/globalValues.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 
 const val roundness = 10
-
+const val iconWeightRatio = 0.8f
 val iconModifier =
     Modifier
         .padding(8.dp)


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and user experience of the `CreateNotePage` and `EditNotePage` in the `BestNotepadEverCreated` app. The most important changes involve adding new imports, modifying the UI elements for better usability, and introducing a new global constant for icon weight ratio.

### UI Improvements:

* Added `MicOff` icon to the imports and replaced the `Button` for starting/stopping recording with an `IconButton` that toggles between `Mic` and `MicOff` icons based on the recording state. (`app/src/main/java/pl/maciejwojs/ar00k/bestnotepadevercreaated/pages/CreateNotePage.kt`) [[1]](diffhunk://#diff-95241a122f91e1d503397a9a3e341a4b809e271a91aaf78bf51a53bf8999c0feR39) [[2]](diffhunk://#diff-95241a122f91e1d503397a9a3e341a4b809e271a91aaf78bf51a53bf8999c0feL168-R205)
* Changed the layout from `Column` to `Row` for better alignment and added a state variable `isBeingRecorded` to manage the recording state. (`app/src/main/java/pl/maciejwojs/ar00k/bestnotepadevercreaated/pages/CreateNotePage.kt`)

### Code Refactoring:

* Replaced the hardcoded weight value of `IconButton` modifiers with the new global constant `iconWeightRatio` for consistency and easier adjustments. (`app/src/main/java/pl/maciejwojs/ar00k/bestnotepadevercreaated/pages/CreateNotePage.kt`, `app/src/main/java/pl/maciejwojs/ar00k/bestnotepadevercreaated/pages/EditNotePage.kt`) [[1]](diffhunk://#diff-95241a122f91e1d503397a9a3e341a4b809e271a91aaf78bf51a53bf8999c0feL239-R281) [[2]](diffhunk://#diff-bcd3149bcd0d4ec96923aba7e67d2f4f9f41bf1d27bbd5d07820e40173f24351L219-R228) [[3]](diffhunk://#diff-bcd3149bcd0d4ec96923aba7e67d2f4f9f41bf1d27bbd5d07820e40173f24351L241-R242)
* Added `iconWeightRatio` to the imports and defined it as a global constant in `globalValues.kt`. (`app/src/main/java/pl/maciejwojs/ar00k/bestnotepadevercreaated/settings/globalValues.kt`)

### State Management:

* Introduced a new `DisposableEffect` to handle the disposal of the recording state, ensuring that the `audioPlayer` and `audioRecorder` are properly stopped when the component is disposed. (`app/src/main/java/pl/maciejwojs/ar00k/bestnotepadevercreaated/pages/CreateNotePage.kt`)